### PR TITLE
Revert back to platform/alz 2025.01.0

### DIFF
--- a/lib/alz_library_metadata.json
+++ b/lib/alz_library_metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "path": "platform/alz",
-      "ref": "2025.02.0"
+      "ref": "2025.01.0"
     }
   ]
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -26,9 +26,6 @@ provider "alz" {
   library_references = [
     {
       custom_url = "${path.root}/lib"
-    },
-    {
-      custom_url = "github.com/richeney-org/alz-custom-library"
     }
   ]
 }


### PR DESCRIPTION
Reverting back from 2025.02.0 to 2025.01.0 of platform/alz so that we can show the update process later