### PR TITLE
Remove Deploy-VM-Backup

### DIFF
--- a/lib/archetype_definitions/identity_custom.alz_archetype_override.yaml
+++ b/lib/archetype_definitions/identity_custom.alz_archetype_override.yaml
@@ -1,7 +1,9 @@
 base_archetype: identity
 name: identity_custom
 policy_assignments_to_add: []
-policy_assignments_to_remove: []
+policy_assignments_to_remove: [
+  "Deploy-VM-Backup",
+]
 policy_definitions_to_add: []
 policy_definitions_to_remove: []
 policy_set_definitions_to_add: []


### PR DESCRIPTION
Example override to remove the VM backup from the identity management group